### PR TITLE
fix: analyze() の path_img 引数を後方互換で復活

### DIFF
--- a/src/yomitoku_client/cli/single.py
+++ b/src/yomitoku_client/cli/single.py
@@ -177,7 +177,7 @@ def single_command(
         ),
     ) as client:
         result = client.analyze(
-            path_img=input_path,
+            img=input_path,
             page_index=page_index,
             dpi=dpi,
             request_timeout=request_timeout,

--- a/src/yomitoku_client/client.py
+++ b/src/yomitoku_client/client.py
@@ -4,6 +4,7 @@ import math
 import os
 import threading
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -25,6 +26,30 @@ from .exceptions import YomitokuInvokeError
 
 logger = set_logger(__name__, "INFO")
 JST = timezone(timedelta(hours=9), name="Asia/Tokyo")
+
+
+def _resolve_img_arg(
+    img: str | bytes | None,
+    path_img: str | bytes | None,
+) -> str | bytes:
+    """Resolve the image argument, accepting the deprecated ``path_img`` alias.
+
+    ``analyze``/``analyze_async`` originally took ``path_img``; it was renamed to
+    ``img`` (which also accepts bytes). ``path_img`` is still accepted for
+    backward compatibility but is deprecated.
+    """
+    if path_img is not None:
+        warnings.warn(
+            "The 'path_img' argument is deprecated and will be removed in a "
+            "future release; use 'img' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        if img is None:
+            img = path_img
+    if img is None:
+        raise TypeError("analyze() missing required argument: 'img'")
+    return img
 
 
 @dataclass
@@ -283,21 +308,26 @@ class YomitokuClient:
 
     async def analyze_async(
         self,
-        img: str|bytes,
+        img: str | bytes | None = None,
         dpi: int = 200,
         page_index: None | int | list = None,
         request_timeout: float | None = None,
         total_timeout: float | None = None,
         *,
+        path_img: str | bytes | None = None,
         content_type: str|None = None,
     ):
+        # 後方互換: 引数名は path_img から img に変更された。旧名 path_img も
+        # 受け付けるが deprecated 扱いとする。
+        img = _resolve_img_arg(img, path_img)
+
         # 画像データ読み込み
         if content_type is None:
             content_type = guess_content_type(img)
         if type(img) == bytes:
-            path_img = '<bytes>'
+            source_name = '<bytes>'
         else:
-            path_img = img
+            source_name = img
         img_bytes, content_type = load_image_bytes(img, content_type, dpi)
         page_index = make_page_index(page_index, len(img_bytes))
 
@@ -317,7 +347,7 @@ class YomitokuClient:
                 index=i,
                 content_type=content_type,
                 body=b,
-                source_name=os.path.basename(path_img),
+                source_name=os.path.basename(source_name),
             )
             for i, b in enumerate(img_bytes)
             if i in page_index
@@ -347,8 +377,8 @@ class YomitokuClient:
             for t in tasks:
                 if not t.done():
                     t.cancel()
-            logger.exception("Analyze failed: %s", path_img)
-            raise YomitokuInvokeError(f"Analyze failed for {path_img}") from e
+            logger.exception("Analyze failed: %s", source_name)
+            raise YomitokuInvokeError(f"Analyze failed for {source_name}") from e
 
         if not results:
             raise YomitokuInvokeError("No page results were returned.")
@@ -441,7 +471,7 @@ class YomitokuClient:
 
     def analyze(
         self,
-        img: str|bytes,
+        img: str | bytes | None = None,
         dpi: int = 200,
         page_index: None | int | list = None,
         request_timeout: float | None = None,

--- a/tests/test_cli_single.py
+++ b/tests/test_cli_single.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path
+
 
 import pytest
 from click.testing import CliRunner
@@ -64,15 +64,19 @@ def _patch_yomitoku_client(monkeypatch, sample_api_result):
 
         def analyze(
             self,
-            path_img,
+            img=None,
             page_index=None,
             dpi=None,
             request_timeout=None,
             total_timeout=None,
+            *,
+            path_img=None,
         ):
+            # 本物の client と同じく旧 path_img 引数も受け付ける
+            resolved = img if img is not None else path_img
             self.analyze_calls.append(
                 {
-                    "path_img": path_img,
+                    "img": resolved,
                     "page_index": page_index,
                     "dpi": dpi,
                     "request_timeout": request_timeout,
@@ -142,7 +146,7 @@ def test_single_command_each_format(
     assert client.endpoint == "test-endpoint"
     assert client.region == "ap-northeast-1"
     assert len(client.analyze_calls) == 1
-    assert client.analyze_calls[0]["path_img"] == str(input_file)
+    assert client.analyze_calls[0]["img"] == str(input_file)
 
     # 出力ファイルが存在すること
     expected_out = output_dir / f"{input_file.stem}.{ext}"
@@ -218,7 +222,7 @@ def test_single_command_with_pages_split_intermediate_and_advanced_options(
     analyze_kwargs = client.analyze_calls[0]
 
     # analyze に渡された値確認
-    assert analyze_kwargs["path_img"] == str(input_file)
+    assert analyze_kwargs["img"] == str(input_file)
     assert analyze_kwargs["dpi"] == 200
     assert analyze_kwargs["request_timeout"] == 10
     assert analyze_kwargs["total_timeout"] == 30

--- a/tests/test_cli_single.py
+++ b/tests/test_cli_single.py
@@ -1,5 +1,5 @@
 import json
-
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
## 背景 / 問題

PR #35 (bytes-input) で `YomitokuClient.analyze` / `analyze_async` の第1引数が `path_img` → `img` に**破壊的リネーム**されましたが、呼び出し側 `cli/single.py` が `path_img=` のままだったため、**現 main の `yomitoku-client single` が `TypeError: missing a required argument: 'img'` で動きません**。また `analyze` は公開APIのため、`path_img=` で呼ぶ外部利用者のコードも黙って壊れます。

## 対応

後方互換を維持しつつ、内部コードは新APIに統一します。

- `analyze` / `analyze_async` が **`img`(新)と `path_img`(旧・deprecated)の両方**を受理。共通ヘルパ `_resolve_img_arg` で解決し、`path_img` 使用時は `DeprecationWarning` を出す。
- `cli/single.py` を新しい `img=` に更新。
- テストの `FakeClient` モックを新シグネチャ(両対応)に追従。アサーションも `img` に更新。

## 挙動

| 呼び出し | 結果 |
|---|---|
| `analyze(img=...)` / `analyze("x.jpg")` | ✅ |
| `analyze(path_img=...)` | ✅(DeprecationWarning) |
| 両方未指定 | `TypeError: missing required argument: 'img'` |


## テスト

`pytest`: 214 passed, 2 failed, 1 skipped。失敗2件は既存の別問題で **#37 で解決**します。
