### PR TITLE
test: レンダリングdpiをfixtureのdpiに揃えて空クロップcrashを解消

### DIFF
--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -207,8 +207,11 @@ def test_batch_command_with_pages_split_visualize_and_advanced_options(
             "--ignore_line_break",
             "--vis_mode",
             "both",
+            # NOTE: image_pdf.json のレイアウト座標は dpi=200 で解析された結果。
+            # レンダリング時の dpi をこれと変えると figure の box が画像外に出て
+            # 空クロップ→cv2.imencode で落ちるため、fixture と同じ dpi を指定する。
             "--dpi",
-            "150",
+            "200",
             "--request_timeout",
             "10",
             "--total_timeout",
@@ -236,7 +239,7 @@ def test_batch_command_with_pages_split_visualize_and_advanced_options(
     assert record["output_dir"] == str(output_dir)
     assert record["endpoint"] == "test-endpoint"
     assert record["region"] == "ap-northeast-1"
-    assert record["dpi"] == 150
+    assert record["dpi"] == 200
     assert record["request_timeout"] == 10
     assert record["total_timeout"] == 30
     assert record["workers"] == 8

--- a/tests/test_cli_single.py
+++ b/tests/test_cli_single.py
@@ -186,8 +186,11 @@ def test_single_command_with_pages_split_intermediate_and_advanced_options(
             "--intermediate_save",
             "--vis_mode",
             "both",
+            # NOTE: image_pdf.json のレイアウト座標は dpi=200 で解析された結果。
+            # レンダリング時の dpi をこれと変えると figure の box が画像外に出て
+            # 空クロップ→cv2.imencode で落ちるため、fixture と同じ dpi を指定する。
             "--dpi",
-            "150",
+            "200",
             "--request_timeout",
             "10",
             "--total_timeout",
@@ -216,7 +219,7 @@ def test_single_command_with_pages_split_intermediate_and_advanced_options(
 
     # analyze に渡された値確認
     assert analyze_kwargs["path_img"] == str(input_file)
-    assert analyze_kwargs["dpi"] == 150
+    assert analyze_kwargs["dpi"] == 200
     assert analyze_kwargs["request_timeout"] == 10
     assert analyze_kwargs["total_timeout"] == 30
 


### PR DESCRIPTION
## 背景 / 問題

CI で以下2テストが `cv2.imencode`(`!_img.empty()`)で失敗していました。

- `tests/test_cli_single.py::test_single_command_with_pages_split_intermediate_and_advanced_options`
- `tests/test_cli_batch.py::test_batch_command_with_pages_split_visualize_and_advanced_options`

## 根本原因(いつ壊れたか)

`git checkout` で二分探索して特定しました。

| commit | 該当2テスト |
|---|---|
| `807dcdb`(2025-11, テスト追加) | ✅ PASS |
| `e6214d8^`(ecd8b18) | ✅ PASS |
| `e6214d8`(2026-02) | ❌ FAIL |

- テストは当初から `--dpi 150` を指定。一方 fixture `tests/data/image_pdf.json` は **dpi=200** で解析されたレイアウト座標を持つ。
- `e6214d8` 以前は `to_html`/`to_markdown`/`to_pdf` に dpi が渡されず、画像ロードは常にデフォルト **dpi=200**。fixture と一致していたため通っていた。
- `e6214d8`「fix DPI not applied to HTML/Markdown/PDF conversion」が `--dpi` を実際にレンダリングへ反映(**正しい修正**)。その結果 `--dpi 150` で画像が 150dpi(小)で読み込まれ、dpi-200 の figure box が画像外へ → 幅/高さ0の空クロップ → `cv2.imencode` がクラッシュ。

## 本質

- `e6214d8` はプロダクトとして正しい。
- 実運用では `analyze(dpi=D)` の結果を同じ `D` でレンダリングするため、この dpi 不一致は**起こり得ない**。テストが「あり得ない組み合わせ(dpi150描画 × dpi200座標)」を作っていただけ。
- numpy スライスは範囲外でも空配列を返すだけなので、**dpi が一致していれば空クロップ自体が発生しない**。レンダラーで空クロップを握りつぶす対症療法は、figure を黙って捨て不整合を隠すため採用しない。

## 修正

テストの `--dpi` を fixture の解析 dpi(**200**)に揃えるのみ。**プロダクトコードの変更なし**。再発防止のコメントも追加。

## テスト

`pytest`: **216 passed, 1 skipped**(失敗0)。