### PR TITLE
fix: Paragraph等のnullableをyomitoku-proサーバーとschema整合

### DIFF
--- a/src/yomitoku_client/models.py
+++ b/src/yomitoku_client/models.py
@@ -46,10 +46,10 @@ class Paragraph(BaseModel):
     """Paragraph data model"""
 
     box: list[int] = Field(description="Bounding box coordinates [x1, y1, x2, y2]")
-    contents: str = Field(description="Text content")
-    direction: str = Field(default="horizontal", description="Text direction")
+    contents: str | None = Field(default=None, description="Text content")
+    direction: str | None = Field(default="horizontal", description="Text direction")
     indent_level: int | None = Field(default=None, description="Indentation level")
-    order: int = Field(description="Reading order")
+    order: int | None = Field(default=None, description="Reading order")
     role: str | None = Field(default=None, description="Paragraph role")
 
 
@@ -57,7 +57,7 @@ class TableCell(BaseModel):
     """Table cell data model"""
 
     box: list[int] = Field(description="Bounding box coordinates")
-    contents: str = Field(description="Cell content")
+    contents: str | None = Field(default=None, description="Cell content")
     col: int = Field(description="Column index")
     row: int = Field(description="Row index")
     col_span: int = Field(description="Column span")
@@ -90,8 +90,8 @@ class Figure(BaseModel):
         description="Table caption",
     )
     decode: str | None = Field(default=None, description="Decoded content")
-    direction: str = Field(default="horizontal", description="Text direction")
-    order: int = Field(description="Reading order")
+    direction: str | None = Field(default="horizontal", description="Text direction")
+    order: int | None = Field(default=None, description="Reading order")
     paragraphs: list[Paragraph] = Field(description="Figure paragraphs")
     role: str | None = Field(default=None, description="Figure role")
 
@@ -112,7 +112,9 @@ class DocumentResult(BaseModel):
     num_page: int = Field(description="Page index in the original document")
     figures: list[Figure] = Field(description="Detected figures")
     paragraphs: list[Paragraph] = Field(description="Detected paragraphs")
-    preprocess: dict[str, Any] = Field(description="Preprocessing information")
+    preprocess: dict[str, Any] | None = Field(
+        default=None, description="Preprocessing information"
+    )
     tables: list[Table] = Field(description="Detected tables")
     words: list[Word] = Field(description="Detected words")
 
@@ -377,7 +379,7 @@ class MultiPageDocumentResult(BaseModel):
             if image_path is not None:
                 corrected_img = correct_rotation_image(
                     images[idx],
-                    angle=self.pages[idx].preprocess.get("angle", 0),
+                    angle=(self.pages[idx].preprocess or {}).get("angle", 0),
                 )
 
             results.append(
@@ -525,7 +527,7 @@ class MultiPageDocumentResult(BaseModel):
             if image_path is not None:
                 corrected_img = correct_rotation_image(
                     images[idx],
-                    angle=self.pages[idx].preprocess.get("angle", 0),
+                    angle=(self.pages[idx].preprocess or {}).get("angle", 0),
                 )
             else:
                 corrected_img = None
@@ -589,7 +591,7 @@ class MultiPageDocumentResult(BaseModel):
             if image_path is not None:
                 corrected_img = correct_rotation_image(
                     images[idx],
-                    angle=self.pages[idx].preprocess.get("angle", 0),
+                    angle=(self.pages[idx].preprocess or {}).get("angle", 0),
                 )
 
             results.append(
@@ -686,7 +688,7 @@ class MultiPageDocumentResult(BaseModel):
         for index in page_index:
             corrected_img = correct_rotation_image(
                 images[index],
-                angle=self.pages[index].preprocess.get("angle", 0),
+                angle=(self.pages[index].preprocess or {}).get("angle", 0),
             )
 
             visualize_img = self.pages[index].visualize(

--- a/src/yomitoku_client/renderers/csv_renderer.py
+++ b/src/yomitoku_client/renderers/csv_renderer.py
@@ -82,7 +82,9 @@ class CSVRenderer(BaseRenderer):
         if self.export_figure_letter and hasattr(data, "figures"):
             for figure in data.figures:
                 if hasattr(figure, "paragraphs"):
-                    for paragraph in sorted(figure.paragraphs, key=lambda x: x.order):
+                    for paragraph in sorted(
+                        figure.paragraphs, key=lambda x: x.order or 0
+                    ):
                         contents = self._paragraph_to_csv(paragraph)
                         elements.append(
                             {
@@ -94,7 +96,7 @@ class CSVRenderer(BaseRenderer):
                         )
 
         # Sort by order
-        elements.sort(key=lambda x: x["order"])
+        elements.sort(key=lambda x: x["order"] or 0)
 
         # Convert to CSV string
         return self._elements_to_csv_string(elements)
@@ -122,7 +124,7 @@ class CSVRenderer(BaseRenderer):
         Returns:
             str: CSV formatted paragraph content
         """
-        contents = paragraph.contents
+        contents = paragraph.contents or ""
 
         if self.ignore_line_break:
             contents = contents.replace("\n", "")

--- a/src/yomitoku_client/renderers/html_renderer.py
+++ b/src/yomitoku_client/renderers/html_renderer.py
@@ -84,7 +84,7 @@ class HTMLRenderer(BaseRenderer):
             elements.extend(figure_elements)
 
         # Sort by order
-        elements.sort(key=lambda x: x["order"])
+        elements.sort(key=lambda x: x["order"] or 0)
 
         # Build list structure
         self._list_to_html(elements)
@@ -157,7 +157,7 @@ class HTMLRenderer(BaseRenderer):
         caption = ""
         if table.caption:
             if hasattr(table.caption, "contents"):
-                caption_text = table.caption.contents
+                caption_text = table.caption.contents or ""
             elif isinstance(table.caption, dict):
                 caption_text = table.caption.get("contents", "")
             else:
@@ -184,7 +184,7 @@ class HTMLRenderer(BaseRenderer):
         Returns:
             dict: HTML element dictionary
         """
-        contents = paragraph.contents
+        contents = paragraph.contents or ""
         contents = self._convert_text_to_html(contents)
 
         if self.ignore_line_break:
@@ -262,7 +262,9 @@ class HTMLRenderer(BaseRenderer):
 
             # Process figure letters if requested
             if self.export_figure_letter and hasattr(figure, "paragraphs"):
-                for paragraph in sorted(figure.paragraphs, key=lambda x: x.order):
+                for paragraph in sorted(
+                    figure.paragraphs, key=lambda x: x.order or 0
+                ):
                     contents = self._paragraph_to_html(paragraph)
                     elements.append(
                         {
@@ -291,7 +293,7 @@ class HTMLRenderer(BaseRenderer):
 
         if caption:
             if hasattr(caption, "contents"):
-                caption_text = caption.contents
+                caption_text = caption.contents or ""
             elif isinstance(caption, dict):
                 caption_text = caption.get("contents", "")
             else:

--- a/src/yomitoku_client/renderers/json_renderer.py
+++ b/src/yomitoku_client/renderers/json_renderer.py
@@ -43,12 +43,12 @@ class JSONRenderer(BaseRenderer):
             # Process tables
             for table in data_dict.get("tables", []):
                 for cell in table.get("cells", []):
-                    if "contents" in cell:
+                    if cell.get("contents") is not None:
                         cell["contents"] = cell["contents"].replace("\n", "")
 
             # Process paragraphs
             for paragraph in data_dict.get("paragraphs", []):
-                if "contents" in paragraph:
+                if paragraph.get("contents") is not None:
                     paragraph["contents"] = paragraph["contents"].replace("\n", "")
 
         # Format JSON with proper settings (matching original)

--- a/src/yomitoku_client/renderers/markdown_renderer.py
+++ b/src/yomitoku_client/renderers/markdown_renderer.py
@@ -105,7 +105,7 @@ class MarkdownRenderer(BaseRenderer):
             elements.extend(figure_elements)
 
         # Sort by order
-        elements.sort(key=lambda x: x["order"])
+        elements.sort(key=lambda x: x["order"] or 0)
         return self._elements_to_markdown_string(elements)
 
     def _paragraph_to_markdown(self, paragraph: Paragraph) -> str:
@@ -118,7 +118,7 @@ class MarkdownRenderer(BaseRenderer):
         Returns:
             str: Markdown formatted paragraph
         """
-        contents = paragraph.contents
+        contents = paragraph.contents or ""
         indent = paragraph.indent_level or 0
 
         if self.ignore_line_break:
@@ -159,7 +159,7 @@ class MarkdownRenderer(BaseRenderer):
             col = cell.col - 1
             row_span = cell.row_span
             col_span = cell.col_span
-            contents = cell.contents
+            contents = cell.contents or ""
 
             contents = escape_markdown_special_chars(contents)
             if self.ignore_line_break:
@@ -179,7 +179,7 @@ class MarkdownRenderer(BaseRenderer):
         if table.caption:
             # Handle caption as object or dict
             if hasattr(table.caption, "contents"):
-                caption_text = table.caption.contents
+                caption_text = table.caption.contents or ""
             elif isinstance(table.caption, dict):
                 caption_text = table.caption.get("contents", "")
             else:
@@ -213,7 +213,7 @@ class MarkdownRenderer(BaseRenderer):
         # Add caption if available
         if table.caption:
             if hasattr(table.caption, "contents"):
-                caption_text = table.caption.contents
+                caption_text = table.caption.contents or ""
             elif isinstance(table.caption, dict):
                 caption_text = table.caption.get("contents", "")
             else:
@@ -329,7 +329,7 @@ class MarkdownRenderer(BaseRenderer):
             # Add caption if available
             if figure.caption:
                 if hasattr(figure.caption, "contents"):
-                    caption_text = figure.caption.contents
+                    caption_text = figure.caption.contents or ""
                 elif isinstance(figure.caption, dict):
                     caption_text = figure.caption.get("contents", "")
                 else:
@@ -344,7 +344,9 @@ class MarkdownRenderer(BaseRenderer):
 
             # Process figure letters if requested
             if self.export_figure_letter and hasattr(figure, "paragraphs"):
-                for paragraph in sorted(figure.paragraphs, key=lambda x: x.order):
+                for paragraph in sorted(
+                    figure.paragraphs, key=lambda x: x.order or 0
+                ):
                     md_content = self._paragraph_to_markdown(paragraph)
                     elements.append(
                         {

--- a/src/yomitoku_client/renderers/searchable_pdf.py
+++ b/src/yomitoku_client/renderers/searchable_pdf.py
@@ -207,7 +207,9 @@ def create_searchable_pdf(
                 )
 
         # Sort containers by reading order
-        containers = sorted(containers, key=lambda c: (c["order"], c["sub_order"]))
+        containers = sorted(
+            containers, key=lambda c: (c["order"] or 0, c["sub_order"])
+        )
 
         all_words = []
         for container in containers:

--- a/src/yomitoku_client/utils.py
+++ b/src/yomitoku_client/utils.py
@@ -567,7 +567,7 @@ def convert_table_array(
         col = cell.col - 1
         row_span = cell.row_span
         col_span = cell.col_span
-        contents = cell.contents
+        contents = cell.contents or ""
 
         table_array[row][col] = contents
         if padding:

--- a/src/yomitoku_client/visualizers/document_visualizer.py
+++ b/src/yomitoku_client/visualizers/document_visualizer.py
@@ -227,7 +227,7 @@ class DocumentVisualizer(BaseVisualizer):
     ):
         """Visualize reading order of document elements"""
         elements = results.paragraphs + results.tables + results.figures
-        elements = sorted(elements, key=lambda x: x.order)
+        elements = sorted(elements, key=lambda x: x.order or 0)
 
         out = self._reading_order_visualizer(img, elements, line_color, tip_size)
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -12,6 +12,7 @@ from yomitoku_client.models import (
     TableCell,
     Word,
 )
+from yomitoku_client.parser import parse_pydantic_model
 
 
 class TestDocumentResult:
@@ -248,6 +249,74 @@ class TestTableCell:
 
         assert cell.row_span == 2
         assert cell.col_span == 3
+
+
+class TestSchemaNullability:
+    """
+    yomitoku-pro(サーバー)側は Paragraph/Figure の contents・direction・order
+    などを ``Union[str|int, None]`` として返す。クライアントのモデルも同様に
+    None を受理できることを保証する(サーバーが None を返しても壊れないため)。
+    """
+
+    def test_paragraph_accepts_none(self):
+        para = Paragraph(box=[0, 0, 1, 1], contents=None, direction=None, order=None)
+        assert para.contents is None
+        assert para.direction is None
+        assert para.order is None
+
+    def test_table_cell_accepts_none_contents(self):
+        cell = TableCell(
+            box=[0, 0, 1, 1],
+            contents=None,
+            col=1,
+            row=1,
+            col_span=1,
+            row_span=1,
+        )
+        assert cell.contents is None
+
+    def test_figure_accepts_none(self):
+        fig = Figure(box=[0, 0, 1, 1], order=None, direction=None, paragraphs=[])
+        assert fig.order is None
+        assert fig.direction is None
+
+    def test_parse_pydantic_model_with_none_fields(self):
+        """サーバーが figure 内 paragraph に None を返すケース(実際の障害再現)。"""
+        data = {
+            "result": [
+                {
+                    "num_page": 0,
+                    "preprocess": None,
+                    "paragraphs": [],
+                    "tables": [],
+                    "words": [],
+                    "figures": [
+                        {
+                            "box": [0, 0, 10, 10],
+                            "order": None,
+                            "direction": None,
+                            "role": None,
+                            "paragraphs": [
+                                {
+                                    "box": [0, 0, 5, 5],
+                                    "contents": None,
+                                    "direction": None,
+                                    "order": None,
+                                    "role": "page_footer",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        model = parse_pydantic_model(data)
+        page = model.pages[0]
+        assert page.preprocess is None
+        para = page.figures[0].paragraphs[0]
+        assert para.contents is None
+        assert para.direction is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景 / 問題

サーバー(yomitoku-pro)の `DocumentAnalyzerSchema` は一部フィールドを **nullable**(`Union[..., None]`)として返すが、クライアント側モデルが**非null必須**になっていたため、正常なサーバーレスポンス(例: OCR空の figure 内 paragraph が `contents=null` / `direction=null`)で pydantic `ValidationError` になっていた。

実際に「解析結果画像を再推論した」際、`figures[N].paragraphs[M].contents / direction` が `null` で落ちる事象を確認。

## サーバー vs クライアントの差分(修正対象)

| モデル | フィールド | server | client(修正前) |
|---|---|---|---|
| Paragraph | contents / direction / order | `str\|None` / `str\|None` / `int\|None` | `str` / `str` / `int` |
| TableCell | contents | `str\|None` | `str` |
| Figure | direction / order | `str\|None` / `int\|None` | `str` / `int` |
| DocumentResult | preprocess | `PreprocessSchema\|None` | `dict`(非null) |

(`role` / `indent_level` / `caption` / `decode` は既に両者一致。`Word` は両者とも非null。)

## 対応

**1. モデルをサーバー契約に合わせて nullable 化**(`models.py`)

**2. None が下流でクラッシュしないようガード**
- renderer: paragraph / cell / caption の `contents` を None のとき `""` 扱い(html / markdown / csv / utils)
- `order` のソートキーを `... or 0` で None 安全化(html / markdown / csv / searchable_pdf / visualizer)
- `preprocess.get(...)` を `(preprocess or {}).get(...)` に(models.py 4箇所)
- json renderer は `contents` が None の場合 `.replace` を呼ばずスキップ

**3. 回帰テスト追加**(`tests/test_parsers.py`)
- Paragraph / TableCell / Figure が None を受理すること
- figure 内 paragraph の `contents`/`direction` が null のレスポンスを `parse_pydantic_model` で解析できること(実障害の再現)

## テスト

`pytest`: **218 passed**, 2 failed, 1 skipped。失敗2件は本PRと無関係な既存の空クロップ(dpi不整合)で **#37 で解決**。