### PR TITLE
sagemaker deploy に --lite オプションを追加

### DIFF
--- a/docs/deploy-yomitoku-pro.md
+++ b/docs/deploy-yomitoku-pro.md
@@ -93,6 +93,7 @@ yomitoku-client sagemaker deploy --endpoint-name yomitoku-sagemaker --instance-t
 | `--endpoint-name` | `yomitoku-sagemaker` | 作成するエンドポイントの名前。CloudFormationのスタック名にも利用されます。 |
 | `--instance-type` | `ml.g4dn.xlarge` | 使用するインスタンスタイプ。`ml.g4dn.xlarge`, `ml.g5.xlarge`, `ml.g6.xlarge`, `ml.c7i.xlarge`, `ml.c7i.2xlarge` が選択可能。検証用途ならデフォルトの`ml.g4dn.xlarge`で十分。性能を求める場合はg5やg6系, インフラコストの安いCPUインスタンス利用の場合はc7i系を推奨。 |
 | `--instance-count` | `1` | デプロイするインスタンス数。 |
+| `--model-lite` / `--no-model-lite` | `--no-model-lite` | GPUインスタンスでlite（動的幅tiny認識器）モデルを利用する場合に指定します。コンテナ環境変数`YOMITOKU_MODEL_LITE`を設定してデプロイします。スループット向上・コスト削減が見込めます。CPUインスタンスは本フラグに関わらず常にliteで動作します。 |
 
 
 !!! warning

--- a/docs/deploy-yomitoku-pro.md
+++ b/docs/deploy-yomitoku-pro.md
@@ -93,7 +93,7 @@ yomitoku-client sagemaker deploy --endpoint-name yomitoku-sagemaker --instance-t
 | `--endpoint-name` | `yomitoku-sagemaker` | 作成するエンドポイントの名前。CloudFormationのスタック名にも利用されます。 |
 | `--instance-type` | `ml.g4dn.xlarge` | 使用するインスタンスタイプ。`ml.g4dn.xlarge`, `ml.g5.xlarge`, `ml.g6.xlarge`, `ml.c7i.xlarge`, `ml.c7i.2xlarge` が選択可能。検証用途ならデフォルトの`ml.g4dn.xlarge`で十分。性能を求める場合はg5やg6系, インフラコストの安いCPUインスタンス利用の場合はc7i系を推奨。 |
 | `--instance-count` | `1` | デプロイするインスタンス数。 |
-| `--model-lite` / `--no-model-lite` | `--no-model-lite` | GPUインスタンスでlite（動的幅tiny認識器）モデルを利用する場合に指定します。コンテナ環境変数`YOMITOKU_MODEL_LITE`を設定してデプロイします。スループット向上・コスト削減が見込めます。CPUインスタンスは本フラグに関わらず常にliteで動作します。 |
+| `--lite` | `False`` | GPUインスタンスでliteモデルを利用する場合に指定します。コンテナ環境変数`YOMITOKU_MODEL_LITE`を設定してデプロイします。スループット向上・コスト削減が見込めます。CPUインスタンスは本フラグに関わらず常にliteで動作します。 |
 
 
 !!! warning

--- a/src/yomitoku_client/cli/sagemaker.py
+++ b/src/yomitoku_client/cli/sagemaker.py
@@ -93,7 +93,8 @@ def configure(profile, region):
     help="Model Package ARN to deploy. If not provided, it will be loaded from the configuration file.",
 )
 @click.option(
-    "--model-lite/--no-model-lite",
+    "--lite",
+    is_flag=True,
     default=False,
     show_default=True,
     help=(
@@ -109,7 +110,7 @@ def deploy(
     instance_type,
     instance_count,
     model_package_arn,
-    model_lite,
+    lite,
     profile,
     region,
 ):
@@ -138,7 +139,7 @@ def deploy(
         instance_type=instance_type,
         model_package_arn=deploy_model_package_arn,
         instance_count=instance_count,
-        model_lite=model_lite,
+        model_lite=lite,
     )
     if not success:
         sys.exit(1)

--- a/src/yomitoku_client/cli/sagemaker.py
+++ b/src/yomitoku_client/cli/sagemaker.py
@@ -92,6 +92,16 @@ def configure(profile, region):
     default=None,
     help="Model Package ARN to deploy. If not provided, it will be loaded from the configuration file.",
 )
+@click.option(
+    "--model-lite/--no-model-lite",
+    default=False,
+    show_default=True,
+    help=(
+        "Opt into the lite (dynamic-width tiny) recognizer on GPU instances by "
+        "setting the YOMITOKU_MODEL_LITE container environment variable. "
+        "CPU instances always run lite regardless of this flag."
+    ),
+)
 @click.option("--profile", default=None, help="AWS profile name.")
 @click.option("--region", default=None, help="AWS region.")
 def deploy(
@@ -99,6 +109,7 @@ def deploy(
     instance_type,
     instance_count,
     model_package_arn,
+    model_lite,
     profile,
     region,
 ):
@@ -127,6 +138,7 @@ def deploy(
         instance_type=instance_type,
         model_package_arn=deploy_model_package_arn,
         instance_count=instance_count,
+        model_lite=model_lite,
     )
     if not success:
         sys.exit(1)

--- a/src/yomitoku_client/resource/cloudformation.yaml
+++ b/src/yomitoku_client/resource/cloudformation.yaml
@@ -16,6 +16,18 @@ Parameters:
   EndpointName:
     Type: String
     Description: Specify suitable name to host the model endpoint. This is a mandatory field.
+  ModelLite:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: >-
+      Opt into the lite (dynamic-width tiny) recognizer on GPU instances by
+      setting the YOMITOKU_MODEL_LITE container environment variable. CPU
+      instances always run lite regardless of this value.
+Conditions:
+  EnableModelLite: !Equals [!Ref ModelLite, "true"]
 Resources:
   SageMakerExecutionRole:
     Type: "AWS::IAM::Role"
@@ -36,6 +48,10 @@ Resources:
       ExecutionRoleArn: !GetAtt SageMakerExecutionRole.Arn
       PrimaryContainer:
         ModelPackageName: !Ref ModelPackageARN
+        Environment: !If
+          - EnableModelLite
+          - YOMITOKU_MODEL_LITE: "true"
+          - !Ref "AWS::NoValue"
   EndPointConfig:
     Type: "AWS::SageMaker::EndpointConfig"
     Properties:

--- a/src/yomitoku_client/sagemaker.py
+++ b/src/yomitoku_client/sagemaker.py
@@ -54,6 +54,7 @@ class SagemakerManager:
         instance_type: str,
         model_package_arn: str,
         instance_count: int,
+        model_lite: bool = False,
     ) -> bool:
         """スタックをデプロイ（作成または更新）する"""
         logger.info("'%s' スタックのデプロイを開始します...", endpoint_name)
@@ -64,6 +65,10 @@ class SagemakerManager:
             {"ParameterKey": "InstanceType", "ParameterValue": instance_type},
             {"ParameterKey": "ModelPackageARN", "ParameterValue": model_package_arn},
             {"ParameterKey": "InstanceCount", "ParameterValue": str(instance_count)},
+            {
+                "ParameterKey": "ModelLite",
+                "ParameterValue": "true" if model_lite else "false",
+            },
         ]
         try:
             if self._stack_exists(endpoint_name):

--- a/tests/test_cli_sagemaker.py
+++ b/tests/test_cli_sagemaker.py
@@ -25,13 +25,19 @@ def mock_sagemaker_manager(monkeypatch):
             record["init_args"] = {"region": region, "profile": profile}
 
         def deploy(
-            self, endpoint_name, instance_type, model_package_arn, instance_count
+            self,
+            endpoint_name,
+            instance_type,
+            model_package_arn,
+            instance_count,
+            model_lite=False,
         ):
             record["deploy_args"] = {
                 "endpoint_name": endpoint_name,
                 "instance_type": instance_type,
                 "model_package_arn": model_package_arn,
                 "instance_count": instance_count,
+                "model_lite": model_lite,
             }
             return True  # 成功をシミュレート
 
@@ -120,6 +126,29 @@ def test_deploy_with_cli_option(runner: CliRunner, mock_sagemaker_manager):
     assert deploy_args["instance_type"] == instance_type
     assert deploy_args["endpoint_name"] == endpoint_name
     assert deploy_args["instance_count"] == 1  # Default value
+    assert deploy_args["model_lite"] is False  # Default value
+
+
+def test_deploy_with_lite_flag(runner: CliRunner, mock_sagemaker_manager):
+    """
+    deploy コマンドで --lite フラグが渡された場合に、model_lite=True で呼ばれることをテストする
+    """
+    cli_arn = "arn:aws:sagemaker:us-west-2:111122223333:model-package/cli-model"
+
+    result = runner.invoke(
+        sagemaker,
+        [
+            "deploy",
+            "--endpoint-name",
+            "test-endpoint",
+            "--model-package-arn",
+            cli_arn,
+            "--lite",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert mock_sagemaker_manager["deploy_args"]["model_lite"] is True
 
 
 def test_deploy_with_config_file(


### PR DESCRIPTION
## 概要

`../yomitoku-sagemaker` で導入された `YOMITOKU_MODEL_LITE` 環境変数を、この client からデプロイ（起動）する際に指定できるようにします。

`yomitoku-client sagemaker deploy` に `--lite` フラグを追加しました。指定するとCloudFormation経由でコンテナ環境変数 `YOMITOKU_MODEL_LITE=true` を設定してデプロイします。

- GPUインスタンス: 既定は通常モデル。`--lite` で lite（動的幅tiny認識器）を有効化 → スループット向上・コスト削減
- CPUインスタンス: 本フラグに関わらず常に lite で動作（サーバ側の挙動に準拠）

## 変更内容

- `cli/sagemaker.py`: `deploy` コマンドに `--lite` オプション（default: false）を追加
- `sagemaker.py`: `SagemakerManager.deploy` に `model_lite: bool` 引数を追加し、CFNパラメータ `ModelLite` を渡す
- `resource/cloudformation.yaml`: `ModelLite` パラメータと `EnableModelLite` Condition を追加。true のときのみ `PrimaryContainer.Environment` に `YOMITOKU_MODEL_LITE=true` を設定（false時は `AWS::NoValue` で未設定）
- `docs/deploy-yomitoku-pro.md`: オプション表に追記

## Note

- unittestがこけているのは#37 で解決予定の内容